### PR TITLE
feat: use unix domain socket to interact with runner

### DIFF
--- a/baihook/patch-libs.cc
+++ b/baihook/patch-libs.cc
@@ -10,13 +10,11 @@
 #include <cerrno>
 
 #include <ctype.h>
-#include <netinet/in.h>
+#include <sys/un.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
 
-static const char *input_host = "127.0.0.1";
-static const int input_port = 65000;
-
+static const char *input_sock = "/tmp/bai-user-input.sock";
 
 OVERRIDE_LIBC_SYMBOL(long, sysconf, int flag)
     switch (flag) {
@@ -44,8 +42,8 @@ int scanf(const char *format, ...)
 {
     va_list args;
     char buffer[1024];
-    struct sockaddr_in addr;
-    int sockfd = socket(PF_INET, SOCK_STREAM, 0);
+    struct sockaddr_un addr;
+    int sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (sockfd < 0) {
         perror("socket");
         return -errno;
@@ -54,9 +52,8 @@ int scanf(const char *format, ...)
     fflush(stdout);
 
     memset(&addr, 0, sizeof(addr));
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = inet_addr(input_host);
-    addr.sin_port = htons(input_port);
+    addr.sun_family = AF_UNIX;
+    strcpy(addr.sun_path, input_sock);
 
     if (connect(sockfd, (struct sockaddr *) &addr, sizeof(addr)) == -1) {
         perror("connect");
@@ -78,8 +75,8 @@ extern "C"
 int vscanf(const char *format, va_list args)
 {
     char buffer[1024];
-    struct sockaddr_in addr;
-    int sockfd = socket(PF_INET, SOCK_STREAM, 0);
+    struct sockaddr_un addr;
+    int sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (sockfd < 0) {
         perror("socket");
         return -errno;
@@ -88,9 +85,8 @@ int vscanf(const char *format, va_list args)
     fflush(stdout);
 
     memset(&addr, 0, sizeof(addr));
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = inet_addr(input_host);
-    addr.sin_port = htons(input_port);
+    addr.sun_family = AF_UNIX;
+    strcpy(addr.sun_path, input_sock);
 
     if (connect(sockfd, (struct sockaddr *) &addr, sizeof(addr)) == -1) {
         perror("connect");

--- a/build.sh
+++ b/build.sh
@@ -10,12 +10,46 @@ usage() {
   echo ""
   echo "Usage: $0 [OPTIONS] DISTRO"
   echo ""
-  echo "DISTRO is either ubuntu or alpine."
+  echo "DISTRO can be one of: centos ubuntu alpine."
+  echo "You can also pass `all` as DISTRO to build Backend.AI Hook for all supported distros."
   echo ""
   echo "OPTIONS"
   echo "  -h, --help        Show this help message and exit."
   echo "  --clean           Run 'make clean' instead of 'make'."
   echo "  --force-cmake     Force to re-run cmake to refresh build scripts."
+}
+
+build() {
+  distro_ver=$1
+  # match the container's user/group with this script
+  user="$(id -u):$(id -g)"
+  # to prevent "fatal: unable to look up current user in the passwd file: no such user" error from git
+  git_fix="-e GIT_COMMITTER_NAME=devops -e GIT_COMMITTER_EMAIL=devops@lablup.com"
+
+  docker build -t lablup/hook-dev:${distro} -f Dockerfile.${distro} .
+  docker_run="docker run --rm -it ${git_fix} -v "$(pwd):/root" -u ${user} -w=/root lablup/hook-dev:${distro} /bin/sh -c"
+
+  if [ "$FORCE_CMAKE" -eq 1 -o ! -f "Makefile" ]; then
+    echo ">> Running CMake to (re-)generate build scripts..."
+    $docker_run 'cmake CMakeLists.txt'
+  fi
+  if [ "$CLEAN" -eq 1 ]; then
+    echo ">> Cleaning up..."
+    $docker_run 'make clean'
+  else
+    echo ">> Building for ${distro} ${arch} ..."
+    $docker_run 'make'
+    cp "baihook/libbaihook.so" "libbaihook.${distro_ver}.${arch}.so"
+    cp "test/test-hook" "test-hook.${distro_ver}.${arch}.bin"
+    cp "test/test-hooked" "test-hooked.${distro_ver}.${arch}.bin"
+  fi
+}
+
+build_all() {
+  FORCE_CMAKE=1
+  distro="ubuntu" build "ubuntu20.04"
+  distro="centos" build "centos7.6"
+  distro="alpine" build "alpine3.8"
 }
 
 while [ $# -gt 0 ]; do
@@ -31,34 +65,17 @@ done
 
 distro="$1"
 arch="$(uname -m)"
+if [ "${arch}" = "arm64" ]; then
+  arch="aarch64"
+fi
+
 case $distro in
-  ubuntu) distro_ver="${distro}20.04" ;;
-  centos) distro_ver="${distro}7.6" ;;
-  alpine) distro_ver="${distro}3.8" ;;
+  ubuntu) build "${distro}20.04" ;;
+  centos) build "${distro}7.6" ;;
+  alpine) build "${distro}3.8" ;;
+  all) build_all ;;
   *)
     echo "Unknown distro value: ${distro}"
     exit 1
 esac
 
-# match the container's user/group with this script
-user="$(id -u):$(id -g)"
-# to prevent "fatal: unable to look up current user in the passwd file: no such user" error from git
-git_fix="-e GIT_COMMITTER_NAME=devops -e GIT_COMMITTER_EMAIL=devops@lablup.com"
-
-docker build -t lablup/hook-dev:${distro} -f Dockerfile.${distro} .
-docker_run="docker run --rm -it ${git_fix} -v "$(pwd):/root" -u ${user} -w=/root lablup/hook-dev:${distro} /bin/sh -c"
-
-if [ "$FORCE_CMAKE" -eq 1 -o ! -f "Makefile" ]; then
-  echo ">> Running CMake to (re-)generate build scripts..."
-  $docker_run 'cmake CMakeLists.txt'
-fi
-if [ "$CLEAN" -eq 1 ]; then
-  echo ">> Cleaning up..."
-  $docker_run 'make clean'
-else
-  echo ">> Building for ${distro} ${arch} ..."
-  $docker_run 'make'
-  cp "baihook/libbaihook.so" "libbaihook.${distro_ver}.${arch}.so"
-  cp "test/test-hook" "test-hook.${distro_ver}.${arch}.bin"
-  cp "test/test-hooked" "test-hooked.${distro_ver}.${arch}.bin"
-fi

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,8 @@ usage() {
 }
 
 build() {
-  distro_ver=$1
+  distro="$1"
+  ver="$2"
   # match the container's user/group with this script
   user="$(id -u):$(id -g)"
   # to prevent "fatal: unable to look up current user in the passwd file: no such user" error from git
@@ -37,19 +38,21 @@ build() {
     echo ">> Cleaning up..."
     $docker_run 'make clean'
   else
-    echo ">> Building for ${distro} ${arch} ..."
+    echo ">> Building for ${distro} ${ver} ${arch} ..."
     $docker_run 'make'
-    cp "baihook/libbaihook.so" "libbaihook.${distro_ver}.${arch}.so"
-    cp "test/test-hook" "test-hook.${distro_ver}.${arch}.bin"
-    cp "test/test-hooked" "test-hooked.${distro_ver}.${arch}.bin"
+    cp "baihook/libbaihook.so" "libbaihook.${distro}${ver}.${arch}.so"
+    cp "test/test-hook" "test-hook.${distro}${ver}.${arch}.bin"
+    cp "test/test-hooked" "test-hooked.${distro}${ver}.${arch}.bin"
   fi
 }
 
 build_all() {
   FORCE_CMAKE=1
-  distro="ubuntu" build "ubuntu20.04"
-  distro="centos" build "centos7.6"
-  distro="alpine" build "alpine3.8"
+  build "ubuntu" "16.04"
+  build "ubuntu" "18.04"
+  build "ubuntu" "20.04"
+  build "centos" "7.6"
+  build "alpine" "3.8"
 }
 
 while [ $# -gt 0 ]; do
@@ -63,19 +66,22 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-distro="$1"
+arg="$1"
 arch="$(uname -m)"
 if [ "${arch}" = "arm64" ]; then
   arch="aarch64"
 fi
 
-case $distro in
-  ubuntu) build "${distro}20.04" ;;
-  centos) build "${distro}7.6" ;;
-  alpine) build "${distro}3.8" ;;
+case $arg in
+  ubuntu) build "${arg}" "20.04" ;;
+  ubuntu16.04) build "${arg}" "16.04" ;;
+  ubuntu18.04) build "${arg}" "18.04" ;;
+  ubuntu20.04) build "${arg}" "20.04" ;;
+  centos) build "${arg}" "7.6" ;;
+  alpine) build "${arg}" "3.8" ;;
   all) build_all ;;
   *)
-    echo "Unknown distro value: ${distro}"
+    echo "Unknown distro value: ${arg}"
     exit 1
 esac
 


### PR DESCRIPTION
Updating `libbaihook` to this version will break compatibility with Backend.AI krunner prior to 22.09.5.