### PR TITLE
fix: get_num_processors_from_cpuset() return 0 on cgroup v2

### DIFF
--- a/baihook/patch-libs.cc
+++ b/baihook/patch-libs.cc
@@ -26,7 +26,7 @@ OVERRIDE_LIBC_SYMBOL(long, sysconf, int flag)
 
         // check cgroup v2 cpuset controller
         result = get_num_processors_from_cpuset("/sys/fs/cgroup/cpuset.cpus");              
-        if(result == 0)
+        if (result == 0)
             // fallback to cgroup v1
             result = get_num_processors_from_cpuset("/sys/fs/cgroup/cpuset/cpuset.cpus");
         return result;

--- a/baihook/patch-libs.cc
+++ b/baihook/patch-libs.cc
@@ -22,7 +22,15 @@ OVERRIDE_LIBC_SYMBOL(long, sysconf, int flag)
     switch (flag) {
     case _SC_NPROCESSORS_ONLN:
     case _SC_NPROCESSORS_CONF:
-        return get_num_processors_from_cpuset("/sys/fs/cgroup/cpuset/cpuset.cpus");
+        int result;
+
+        // check cgroup v2 cpuset controller (since linux 5.0)
+        result = get_num_processors_from_cpuset("/sys/fs/cgroup/cpuset.cpus");              
+        if(result == 0)
+            // fallback to cgroup v1
+            result = get_num_processors_from_cpuset("/sys/fs/cgroup/cpuset/cpuset.cpus");
+        return result;
+
     /* though getpagesize() call is considered as deprecated,
      * without this, redis-server from APT package will stick on a deadlock
      * during intialization process due to their own jemalloc function loading mechanism.

--- a/baihook/patch-libs.cc
+++ b/baihook/patch-libs.cc
@@ -25,10 +25,10 @@ OVERRIDE_LIBC_SYMBOL(long, sysconf, int flag)
         int result;
 
         // check cgroup v2 cpuset controller
-        result = get_num_processors_from_cpuset("/sys/fs/cgroup/cpuset.cpus");              
+        result = get_num_processors_from_cpuset("/sys/fs/cgroup/cpuset.cpus.effective");              
         if (result == 0)
             // fallback to cgroup v1
-            result = get_num_processors_from_cpuset("/sys/fs/cgroup/cpuset/cpuset.cpus");
+            result = get_num_processors_from_cpuset("/sys/fs/cgroup/cpuset/cpuset.effective_cpus");
         return result;
 
     /* though getpagesize() call is considered as deprecated,

--- a/baihook/patch-libs.cc
+++ b/baihook/patch-libs.cc
@@ -24,7 +24,7 @@ OVERRIDE_LIBC_SYMBOL(long, sysconf, int flag)
     case _SC_NPROCESSORS_CONF:
         int result;
 
-        // check cgroup v2 cpuset controller (since linux 5.0)
+        // check cgroup v2 cpuset controller
         result = get_num_processors_from_cpuset("/sys/fs/cgroup/cpuset.cpus");              
         if(result == 0)
             // fallback to cgroup v1


### PR DESCRIPTION
This PR makes `get_num_processors_from_cpuset()` cover the cgroup v2.
and resolves https://github.com/lablup/backend.ai/issues/964

But, at this moment, backend.ai doesn't support cgroup v2 yet. (https://github.com/lablup/backend.ai/issues/865)
So, please handle this after supporting cgroup v2 in backend.ai.