### PR TITLE
feat: Add support for build target CentOS 8

### DIFF
--- a/Dockerfile.centos8.0
+++ b/Dockerfile.centos8.0
@@ -1,0 +1,16 @@
+FROM centos:centos8
+
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
+# Install necessary packages
+RUN dnf install -y dnf-plugins-core \
+    && dnf install -y epel-release \
+    && dnf config-manager --set-enabled powertools \
+    && dnf install -y gcc gcc-c++ make cmake git kernel-devel ca-certificates \
+    && dnf install -y libstdc++-static which
+
+# Enable the new toolchain always in any followed docker run commands
+COPY docker.centos8.0.entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# vim: ft=dockerfile

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ usage() {
   echo ""
   echo "Usage: $0 [OPTIONS] DISTRO"
   echo ""
-  echo "Available DISTROs are: ubuntu (resolved as ubuntu18.04), ubuntu18.04, ubuntu20.04, ubuntu22.04 or alpine."
+  echo "Available DISTROs are: ubuntu (resolved as ubuntu18.04), ubuntu18.04, ubuntu20.04, ubuntu22.04, alpine, centos or centos8.0"
   echo ""
   echo "OPTIONS"
   echo "  -h, --help        Show this help message and exit."
@@ -45,6 +45,7 @@ case $distro in
 	  distro_ver="ubuntu18.04"
 	  ;;
   centos) distro_ver="${distro}7.6" ;;
+  centos8.0) distro_ver="${distro}" ;;
   alpine) distro_ver="${distro}3.8" ;;
   *)
     echo "Unknown distro value: ${distro}"

--- a/docker.centos8.0.entrypoint.sh
+++ b/docker.centos8.0.entrypoint.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+export CC=$(which gcc)
+export CXX=$(which g++)
+exec "$@"

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,7 @@ arch="x86_64"
 case $distro in
   ubuntu) distro_ver="${distro}16.04" ;;
   centos) distro_ver="${distro}7.6" ;;
+  centos8.0) distro_ver="${distro}" ;;
   alpine) distro_ver="${distro}3.8" ;;
   *)
     echo "Unknown distro value: ${distro}"


### PR DESCRIPTION
This PR modifies the build script to enable building the centos8 libbackend-hook binary.

Ref: https://github.com/lablup/backend.ai/pull/2220

## build

To build the centos8 binary, enter the following command:

```
❯ ./build.sh centos8.0
```

## test

Tested by `test.sh`.

```
❯ ./test.sh centos8.0
>> Running unit tests for centos8.0 x86_64
[==========] Running 2 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from has_prefix
[ RUN      ] has_prefix.basic
[       OK ] has_prefix.basic (0 ms)
[----------] 1 test from has_prefix (0 ms total)

[----------] 1 test from cpuset_parsing
[ RUN      ] cpuset_parsing.basic
[       OK ] cpuset_parsing.basic (0 ms)
[----------] 1 test from cpuset_parsing (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 2 tests.

>> Running integration tests for centos8.0 x86_64
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from sysconf
[ RUN      ] sysconf.hooked
[       OK ] sysconf.hooked (0 ms)
[----------] 1 test from sysconf (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
```